### PR TITLE
DataTable: defaultSort has no effect [cuba-platform/cuba-react#23]

### DIFF
--- a/src/generators/react-typescript/app/template/package.json
+++ b/src/generators/react-typescript/app/template/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@cuba-platform/react": "0.3.1-dev.1",
+    "@cuba-platform/react": "0.3.1-dev.2",
     "@cuba-platform/rest": "^0.6.0",
     "antd": "^3.23.4",
     "mobx": "^4.13.0",

--- a/src/generators/react-typescript/entity-management/template/EntityManagementBrowser.tsx.ejs
+++ b/src/generators/react-typescript/entity-management/template/EntityManagementBrowser.tsx.ejs
@@ -98,7 +98,6 @@ class <%= listComponentName %>Component extends React.Component<MainStoreInjecte
                  onRowSelectionChange={this.handleRowSelectionChange}
                  hideSelectionColumn={true}
                  buttons={buttons}
-                 defaultSort={'-updateTs'}
       />
     );
   }

--- a/src/test/fixtures/react-client/src/app/entity-management/CarTable.tsx
+++ b/src/test/fixtures/react-client/src/app/entity-management/CarTable.tsx
@@ -111,7 +111,6 @@ class CarTableComponent extends React.Component<
         onRowSelectionChange={this.handleRowSelectionChange}
         hideSelectionColumn={true}
         buttons={buttons}
-        defaultSort={"-updateTs"}
       />
     );
   }


### PR DESCRIPTION
defaultSort prop is removed.
Default sorting is now determined by dataCollection.sort.